### PR TITLE
Print MSSQL* events to stdout

### DIFF
--- a/windows/mssql-server-windows-express/start.ps1
+++ b/windows/mssql-server-windows-express/start.ps1
@@ -54,4 +54,9 @@ if ($null -ne $dbs -And $dbs.Length -gt 0){
 }
 
 Write-Verbose "Started SQL Server."
-while ($true) { Start-Sleep -Seconds 3600 }
+$lastCheck = (Get-Date).AddSeconds(-2)
+while ($true) {
+	Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	
+	$lastCheck = Get-Date
+	Start-Sleep -Seconds 2
+}

--- a/windows/mssql-server-windows/start.ps1
+++ b/windows/mssql-server-windows/start.ps1
@@ -54,4 +54,9 @@ if ($null -ne $dbs -And $dbs.Length -gt 0){
 }
 
 Write-Verbose "Started SQL Server."
-while ($true) { Start-Sleep -Seconds 3600 }
+$lastCheck = (Get-Date).AddSeconds(-2)
+while ($true) {
+	Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	
+	$lastCheck = Get-Date
+	Start-Sleep -Seconds 2
+}


### PR DESCRIPTION
As a user, I want to be able to view SQL-related event log entries without having to `docker exec powershell get-winevent` or similar.
 
PR adds display of events (via `Get-EventLog`) matching the Source filter of MSSQL*. I arbitrarily selected 2s as the refresh interval for logs because I wasn't sure if setting it lower (e.g., 1s) would have negative implications. 