### PR TITLE
Update README.md with 'sa' password requiremenets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For any issues, please file under this GitHub project on the [Issues section](ht
 
 - When using the Windows Docker CLI you must use double quotes instead of single ticks for the environment variables, else the mssql-server-linux image won't find the `ACCEPT_EULA` or `SA_PASSWORD` variables which are required to start the container.
 
+- The 'sa' password has a minimum complexity requirements (8 characters, uppercase, lowercase, alphanumerical and/or non-alphanumerical)
 
 ## License
 


### PR DESCRIPTION
Added 'sa' password requirements.

At the moment, when I specify password 'test' I can't login. The best solution would be to fail to start when the password requirements are not met, but for now adding note about minimum password requirements should be more than enough to help users deal with the problem.