### PR TITLE
Allow for running initialization scripts

### DIFF
--- a/linux/preview/Dockerfile
+++ b/linux/preview/Dockerfile
@@ -14,6 +14,9 @@ EXPOSE 1433
 # Copy all SQL Server runtime files from build drop into image.
 COPY ./install /
 
+# Add symlink for sqlcmd on PATH
+RUN ln -s /opt/mssql-tools/bin/sqlcmd /usr/local/bin/sqlcmd
+
 # Copy initialization scripts.
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY docker-entrypoint-initdb.sh /usr/local/bin/

--- a/linux/preview/Dockerfile
+++ b/linux/preview/Dockerfile
@@ -5,11 +5,18 @@
 # Base OS layer: Latest Ubuntu LTS.
 FROM ubuntu:16.04
 
+# For initialization scripts.
+VOLUME /docker-entrypoint-initdb.d
+
 # Default SQL Server TCP/Port.
 EXPOSE 1433
 
 # Copy all SQL Server runtime files from build drop into image.
 COPY ./install /
 
+# Copy initialization scripts.
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint-initdb.sh /usr/local/bin/
+
 # Run SQL Server process.
-CMD /opt/mssql/bin/sqlservr.sh
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/linux/preview/README.md
+++ b/linux/preview/README.md
@@ -30,7 +30,13 @@ Starting with the CTP 1.4 (March 17, 2017) release the mssql-tools package inclu
 ```
 docker exec -it <container_id|container_name> /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P <your_password>
 ```
-You can also use the tools in an entrypoint.sh script to do things like create databases or logins, attach databases, import data, or other setup tasks.  See this example of [using an entrypoint.sh script to create a database and schema and bcp in some data](https://github.com/twright-msft/mssql-node-docker-demo-app).
+
+~~You can also use the tools in an entrypoint.sh script to do things like create databases or logins, attach databases, import data, or other setup tasks.  See this example of [using an entrypoint.sh script to create a database and schema and bcp in some data](https://github.com/twright-msft/mssql-node-docker-demo-app).~~
+
+You can also mount scripts to into the container to do things like create databases or logins, attach databases, import data, or other setup tasks. When a container is started for the first time, it will execute any files with extensions .sh or .sql that are found in /docker-entrypoint-initdb.d. Files will be executed in alphabetical order. You can easily populate your SQL Server services by mounting scripts into that directory and provide custom images with contributed data.
+
+For example:
+> ``docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=yourStrong(!)Password' -p 1433:1433 -v $PWD/initdb:/docker-entrypoint-initdb.d -d microsoft/mssql-server-linux``
 
 You can connect to the SQL Server instance in the container from outside the container by using various command line and GUI tools on the host or remote computers.  See the [Connect and Query](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-connect-and-query-sqlcmd) topic in the SQL Server on Linux documentation.
 

--- a/linux/preview/docker-entrypoint-initdb.sh
+++ b/linux/preview/docker-entrypoint-initdb.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# wait for database to start...
+for i in {30..0}; do
+  if sqlcmd -U SA -P $SA_PASSWORD -Q 'SELECT 1;' &> /dev/null; then
+    echo "$0: SQL Server started"
+    break
+  fi
+  echo "$0: SQL Server startup in progress..."
+  sleep 1
+done
+
+echo "$0: Initializing database"
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.sh)     echo "$0: running $f"; . "$f" ;;
+    *.sql)    echo "$0: running $f"; sqlcmd -U SA -P $SA_PASSWORD -X -i  "$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done
+echo "$0: SQL Server Database ready"

--- a/linux/preview/docker-entrypoint.sh
+++ b/linux/preview/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "$0: Starting SQL Server"
+docker-entrypoint-initdb.sh & /opt/mssql/bin/sqlservr.sh


### PR DESCRIPTION
Applies to mssql-server-linux, issue #11, adding functionality to mount initialization scripts and execute them when the container is started.

When a container is started for the first time, it will execute any files with extensions .sh or .sql that are found in /docker-entrypoint-initdb.d. Files will be executed in alphabetical order. You can easily populate your SQL Server services by mounting scripts into that directory and provide custom images with contributed data.