### PR TITLE
[mssql-server-windows] Attaching a db from files stored in Azure page blobs

### DIFF
--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -28,7 +28,7 @@ start-service MSSQLSERVER
 
 if($sa_password -ne "_")
 {
-	Write-Verbose "Changing SA login credentials"
+    Write-Verbose "Changing SA login credentials"
     $sqlcmd = "ALTER LOGIN sa with password=" +"'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
     Invoke-Sqlcmd -Query $sqlcmd
 }
@@ -43,7 +43,6 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
 	    
     Foreach($db in $dbs) 
     {
-        
         if($db.saskey.length -gt 0)
         { 
             $saskey = $true 
@@ -52,9 +51,9 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
         { 
             $saskey = $false 
         }
-         
-		$files = @();
-		Foreach($file in $db.dbFiles)
+            
+        $files = @();
+        Foreach($file in $db.dbFiles)
         {
             $files += "(FILENAME = N'$($file)')";
             
@@ -65,15 +64,15 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
                 $sql_credential = "IF NOT EXISTS (SELECT 1 FROM SYS.CREDENTIALS WHERE NAME = '" + $blob_container + "') BEGIN CREATE CREDENTIAL [" + $blob_container + "] WITH IDENTITY='SHARED ACCESS SIGNATURE', SECRET= '" + $db.saskey + "' END;"              
             
                 Write-Verbose "Invoke-Sqlcmd -Query $($sql_credential)"
-	            Invoke-Sqlcmd -Query $sql_credential
+                Invoke-Sqlcmd -Query $sql_credential
             }
-		}
+        }
 
-		$files = $files -join ","
-		$sqlcmd = "sp_detach_db $($db.dbName);CREATE DATABASE $($db.dbName) ON $($files) FOR ATTACH ;"
+        $files = $files -join ","
+        $sqlcmd = "sp_detach_db $($db.dbName);CREATE DATABASE $($db.dbName) ON $($files) FOR ATTACH ;"
 
-		Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
-		Invoke-Sqlcmd -Query $sqlcmd
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        Invoke-Sqlcmd -Query $sqlcmd
 	}
 }
 

--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -14,7 +14,8 @@ param(
 )
 
 
-if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y"){
+if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
 	Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
 	Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
 
@@ -25,7 +26,8 @@ if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y"){
 Write-Verbose "Starting SQL Server"
 start-service MSSQLSERVER
 
-if($sa_password -ne "_"){
+if($sa_password -ne "_")
+{
 	Write-Verbose "Changing SA login credentials"
     $sqlcmd = "ALTER LOGIN sa with password=" +"'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
     Invoke-Sqlcmd -Query $sqlcmd
@@ -35,33 +37,36 @@ $attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
 
 $dbs = $attach_dbs_cleaned | ConvertFrom-Json
 
-if ($null -ne $dbs -And $dbs.Length -gt 0){
-	Write-Verbose "Attaching $($dbs.Length) database(s)"
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
 	    
-
-    Foreach($db in $dbs)
-	{
+    Foreach($db in $dbs) 
+    {
         
-        if($db.saskey.length -gt 0){ 
+        if($db.saskey.length -gt 0)
+        { 
             $saskey = $true 
         }
-        else{ 
+        else
+        { 
             $saskey = $false 
         }
          
 		$files = @();
-		Foreach($file in $db.dbFiles){
-			$files += "(FILENAME = N'$($file)')";
+		Foreach($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";
             
             # check for a saskey and create one credential per blob Container                  
-            if($saskey){
-                $container = (Split-Path $file).Replace('\','/');                                         
-                $sql_credential = "IF NOT EXISTS (SELECT 1 FROM SYS.CREDENTIALS WHERE NAME = '" + $container + "') BEGIN CREATE CREDENTIAL [" + $container + "] WITH IDENTITY='SHARED ACCESS SIGNATURE', SECRET= '" + $db.saskey + "' END;"              
+            if($saskey)
+            {
+                $blob_container = (Split-Path $file).Replace('\','/');                                         
+                $sql_credential = "IF NOT EXISTS (SELECT 1 FROM SYS.CREDENTIALS WHERE NAME = '" + $blob_container + "') BEGIN CREATE CREDENTIAL [" + $blob_container + "] WITH IDENTITY='SHARED ACCESS SIGNATURE', SECRET= '" + $db.saskey + "' END;"              
             
                 Write-Verbose "Invoke-Sqlcmd -Query $($sql_credential)"
-		        Invoke-Sqlcmd -Query $sql_credential
+	            Invoke-Sqlcmd -Query $sql_credential
             }
-
 		}
 
 		$files = $files -join ","
@@ -75,7 +80,8 @@ if ($null -ne $dbs -And $dbs.Length -gt 0){
 Write-Verbose "Started SQL Server."
 
 $lastCheck = (Get-Date).AddSeconds(-2) 
-while ($true) { 
+while ($true) 
+{ 
     Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
     $lastCheck = Get-Date 
     Start-Sleep -Seconds 2 


### PR DESCRIPTION
Based on a couple of requests to be able to attach a database from files stored in Azure Blobs, we made the following code changes to extend the **attach_dbs** environment variable and support this scenario. At a high level, we added saskey to be able to create a sql credential before attaching the db from Azure page blobs (based on this: https://docs.microsoft.com/en-us/sql/relational-databases/databases/sql-server-data-files-in-microsoft-azure article). 

Let us know what you think - We are interested in your feedback before merging the change and building a new Docker image.
