### PR TITLE
sqlcmd symlink for easier run usage and examples

### DIFF
--- a/linux/preview/CentOS/Dockerfile
+++ b/linux/preview/CentOS/Dockerfile
@@ -27,6 +27,9 @@ RUN curl https://packages.microsoft.com/config/rhel/7/mssql-server.repo > /etc/y
     ACCEPT_EULA=Y yum install -y mssql-server mssql-tools && \
     yum clean all
 
+# Symlink sqlcmd for easier usage
+RUN ln -s /opt/mssql-tools/bin/sqlcmd /usr/bin/sqlcmd
+
 ENV PATH=${PATH}:/opt/mssql/bin:/opt/mssql-tools/bin
 
 # Default SQL Server TCP/Port

--- a/linux/preview/README.md
+++ b/linux/preview/README.md
@@ -58,7 +58,7 @@ $ make run
 ##  Connect to Microsoft SQL Server
 Starting with the CTP 1.4 (March 17, 2017) release the mssql-tools package including sqlcmd, bcp are included in the image.  You can connect to the SQL Server using the sqlcmd tool inside of the container by using the following command on the host:
 ```
-docker exec -it <container_id|container_name> /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P <your_password>
+docker exec -it <container_id|container_name> sqlcmd -S localhost -U sa -P <your_password>
 ```
 You can also use the tools in an entrypoint.sh script to do things like create databases or logins, attach databases, import data, or other setup tasks.  See this example of [using an entrypoint.sh script to create a database and schema and bcp in some data](https://github.com/twright-msft/mssql-node-docker-demo-app).
 

--- a/linux/preview/RHEL/Dockerfile
+++ b/linux/preview/RHEL/Dockerfile
@@ -40,6 +40,9 @@ RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms,packages-microsoft-c
     go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
     yum clean all
 
+# Symlink sqlcmd for easier usage
+RUN ln -s /opt/mssql-tools/bin/sqlcmd /usr/bin/sqlcmd
+
 ENV PATH=${PATH}:/opt/mssql/bin:/opt/mssql-tools/bin
 
 # Default SQL Server TCP/Port

--- a/linux/preview/Ubuntu/Dockerfile
+++ b/linux/preview/Ubuntu/Dockerfile
@@ -11,5 +11,8 @@ EXPOSE 1433
 # Copy all SQL Server runtime files from build drop into image.
 COPY ./install /
 
+# Symlink sqlcmd for easier usage
+RUN ln -s /opt/mssql-tools/bin/sqlcmd /usr/bin/sqlcmd
+
 # Run SQL Server process.
 CMD /opt/mssql/bin/sqlservr


### PR DESCRIPTION
In all cases I used these docker images I symlinked sqlcmd for easier usage.

This makes it much easier to run docker containers.

Comparison:
`docker run -it --rm microsoft/mssql-server-linux sqlcmd`
`docker run -it --rm microsoft/mssql-server-linux /opt/mssql-tools/bin/sqlcmd`