### PR TITLE
Add support for reading SA password from Docker secrets for Windows images

### DIFF
--- a/windows/mssql-server-windows-developer/dockerfile
+++ b/windows/mssql-server-windows-developer/dockerfile
@@ -6,9 +6,10 @@ LABEL maintainer "Perry Skountrianos"
 ENV exe "https://go.microsoft.com/fwlink/?linkid=840945"
 ENV box "https://go.microsoft.com/fwlink/?linkid=840944"
 
-ENV sa_password _
-ENV attach_dbs "[]"
-ENV ACCEPT_EULA _
+ENV sa_password="_" \
+    attach_dbs="[]" \
+    ACCEPT_EULA="_" \
+    sa_password_path="C:\ProgramData\Docker\secrets\sa-password"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -26,6 +26,15 @@ if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
 Write-Verbose "Starting SQL Server"
 start-service MSSQLSERVER
 
+if($sa_password -eq "_") {
+    if (Test-Path $env:sa_password_path) {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
 if($sa_password -ne "_")
 {
     Write-Verbose "Changing SA login credentials"

--- a/windows/mssql-server-windows-express/dockerfile
+++ b/windows/mssql-server-windows-express/dockerfile
@@ -5,9 +5,10 @@ LABEL maintainer "Perry Skountrianos"
 # SQL Server 2017
 ENV sql_express_download_url "https://go.microsoft.com/fwlink/?linkid=829176"
 
-ENV sa_password _
-ENV attach_dbs "[]"
-ENV ACCEPT_EULA _
+ENV sa_password="_" \
+    attach_dbs="[]" \
+    ACCEPT_EULA="_" \
+    sa_password_path="C:\ProgramData\Docker\secrets\sa-password"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows/mssql-server-windows-express/start.ps1
+++ b/windows/mssql-server-windows-express/start.ps1
@@ -26,6 +26,15 @@ if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
 Write-Verbose "Starting SQL Server"
 start-service MSSQL`$SQLEXPRESS
 
+if($sa_password -eq "_") {
+    if (Test-Path $env:sa_password_path) {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
 if($sa_password -ne "_")
 {
     Write-Verbose "Changing SA login credentials"

--- a/windows/mssql-server-windows/dockerfile
+++ b/windows/mssql-server-windows/dockerfile
@@ -6,9 +6,10 @@ LABEL maintainer "Perry Skountrianos"
 ENV exe "https://go.microsoft.com/fwlink/?linkid=835677"
 ENV box "https://go.microsoft.com/fwlink/?linkid=835679"
 
-ENV sa_password _
-ENV attach_dbs "[]"
-ENV ACCEPT_EULA _
+ENV sa_password="_" \
+    attach_dbs="[]" \
+    ACCEPT_EULA="_" \
+    sa_password_path="C:\ProgramData\Docker\secrets\sa-password"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows/mssql-server-windows/start.ps1
+++ b/windows/mssql-server-windows/start.ps1
@@ -26,6 +26,15 @@ if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
 Write-Verbose "Starting SQL Server"
 start-service MSSQLSERVER
 
+if($sa_password -eq "_") {
+    if (Test-Path $env:sa_password_path) {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
 if($sa_password -ne "_")
 {
     Write-Verbose "Changing SA login credentials"


### PR DESCRIPTION
Updated the startup script so it can read the SA password from a known file location instead of an environment variable. The location is set with a default in the Dockerfile to read from a Docker secret.

Using the secret is optional - if the secret doesn't exist, or an environment variable is specified, the variable takes precedence, so current behaviour is preserved.

To use a secret for the password, users can do this in swarm mode:

```
docker secret create sa-password my-password-file.txt
docker service create --image microsoft/mssql-server-windows-express --secret sa-password [etc]
```

Then the SA password is stored encrypted in the swarm and is only available in plaintext inside the container.
