### PR TITLE
Enable graceful shutdown

### DIFF
--- a/linux/mssql-server-linux/Dockerfile
+++ b/linux/mssql-server-linux/Dockerfile
@@ -12,4 +12,4 @@ EXPOSE 1433
 COPY ./install /
 
 # Run SQL Server process.
-CMD /opt/mssql/bin/sqlservr
+CMD [ "/opt/mssql/bin/sqlservr" ]


### PR DESCRIPTION
The shell syntax in the `CMD` directive causes the entire setup to swallow SIGINT signals and therefore hinders MSSQL to shutdown gracefully when `docker stop` or `docker-compose stop` are being used.

This tiny fix makes `sqlserver` PID 1, forwards signals correctly and enables graceful shutdown.