### PR TITLE
RHEL/CentOS: update VOLUME to match Documentation instructions

### DIFF
--- a/linux/preview/CentOS/Dockerfile
+++ b/linux/preview/CentOS/Dockerfile
@@ -38,7 +38,7 @@ USER 10001
 # Default SQL Server TCP/Port
 EXPOSE 1433
 
-VOLUME /var/opt/mssql/data
+VOLUME /var/opt/mssql
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 ENTRYPOINT [ "uid_entrypoint" ]

--- a/linux/preview/RHEL/Dockerfile
+++ b/linux/preview/RHEL/Dockerfile
@@ -43,7 +43,7 @@ USER 10001
 # Default SQL Server TCP/Port
 EXPOSE 1433
 
-VOLUME /var/opt/mssql/data
+VOLUME /var/opt/mssql
 
 ### user name recognition at runtime w/ an arbitrary uid - for OpenShift deployments
 ENTRYPOINT [ "uid_entrypoint" ]


### PR DESCRIPTION
The Documentation for mssql in Docker uses the /var/opt/mssql mount point
while the Dockerfile is using the /var/opt/mssql/data mount point.

If the user specifies a persistent volume for the documented mount point,
the data may not be persisted due to Docker mounting the data dir separately
to non-persistent storage.