### PR TITLE
Added ability to read SA_PASSWORD from SA_PASSWORD_FILE

### DIFF
--- a/linux/mssql-server-linux/Dockerfile
+++ b/linux/mssql-server-linux/Dockerfile
@@ -11,5 +11,9 @@ EXPOSE 1433
 # Copy all SQL Server runtime files from build drop into image.
 COPY ./install /
 
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
 # Run SQL Server process.
-CMD [ "/opt/mssql/bin/sqlservr" ]
+CMD [ "/entrypoint.sh" ]

--- a/linux/mssql-server-linux/entrypoint.sh
+++ b/linux/mssql-server-linux/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# This script sets the SA_PASSWORD variable from a SA_PASSWORD_FILE if 
+# SA_PASSWORD isn't already set and the file pointed to by SA_PASSWORD_FILE
+# does exit.
+
+# This enables the password to be set through mounted secrets, via Docker 
+# Secrets or Kubernetes Secrets.
+
+set -Ee
+
+trap "Error on line $LINENO" ERR
+
+
+if [[ "$SA_PASSWORD" == "" && "$SA_PASSWORD_FILE" != "" && -e $SA_PASSWORD_FILE ]]; then
+    password="$(< "${SA_PASSWORD_FILE}")"
+    export SA_PASSWORD="$password"
+fi
+
+/opt/mssql/bin/sqlservr


### PR DESCRIPTION
Adds an `entrypoint.sh` script that reads `SA_PASSWORD` from a file defined by `SA_PASSWORD_FILE` if `SA_PASSWORD` isn't already set.

This is for issue #326 .