### PR TITLE
Remove line break in attach_dbs variable

### DIFF
--- a/windows/mssql-server-windows-developer/readme.md
+++ b/windows/mssql-server-windows-developer/readme.md
@@ -79,8 +79,7 @@ The image provides two environment variables to optionally set: </br>
 
 This example shows all parameters in action:
 ```
-docker run -d -p 1433:1433 -v C:/temp/:C:/temp/ -e sa_password=<YOUR SA PASSWORD> -e ACCEPT_EULA=Y -e attach_dbs="[{'dbName':'SampleDB','dbFiles':['C:\\temp\\sampledb.mdf','C:\\temp\\sampledb_log.
-ldf']}]" microsoft/mssql-server-windows-developer
+docker run -d -p 1433:1433 -v C:/temp/:C:/temp/ -e sa_password=<YOUR SA PASSWORD> -e ACCEPT_EULA=Y -e attach_dbs="[{'dbName':'SampleDB','dbFiles':['C:\\temp\\sampledb.mdf','C:\\temp\\sampledb_log.ldf']}]" microsoft/mssql-server-windows-developer
 ```
 
 <a name=sample-details></a>

--- a/windows/mssql-server-windows-express/readme.md
+++ b/windows/mssql-server-windows-express/readme.md
@@ -79,8 +79,7 @@ The image provides two environment variables to optionally set: </br>
 
 This example shows all parameters in action:
 ```
-docker run -d -p 1433:1433 -v C:/temp/:C:/temp/ -e sa_password=<YOUR SA PASSWORD> -e ACCEPT_EULA=Y -e attach_dbs="[{'dbName':'SampleDB','dbFiles':['C:\\temp\\sampledb.mdf','C:\\temp\\sampledb_log.
-ldf']}]" microsoft/mssql-server-windows-express
+docker run -d -p 1433:1433 -v C:/temp/:C:/temp/ -e sa_password=<YOUR SA PASSWORD> -e ACCEPT_EULA=Y -e attach_dbs="[{'dbName':'SampleDB','dbFiles':['C:\\temp\\sampledb.mdf','C:\\temp\\sampledb_log.ldf']}]" microsoft/mssql-server-windows-express
 ```
 
 <a name=sample-details></a>

--- a/windows/mssql-server-windows/readme.md
+++ b/windows/mssql-server-windows/readme.md
@@ -79,8 +79,7 @@ The image provides two environment variables to optionally set: </br>
 
 This example shows all parameters in action:
 ```
-docker run -d -p 1433:1433 -v C:/temp/:C:/temp/ -e sa_password=<YOUR SA PASSWORD> -e ACCEPT_EULA=Y -e attach_dbs="[{'dbName':'SampleDB','dbFiles':['C:\\temp\\sampledb.mdf','C:\\temp\\sampledb_log.
-ldf']}]" microsoft/mssql-server-windows
+docker run -d -p 1433:1433 -v C:/temp/:C:/temp/ -e sa_password=<YOUR SA PASSWORD> -e ACCEPT_EULA=Y -e attach_dbs="[{'dbName':'SampleDB','dbFiles':['C:\\temp\\sampledb.mdf','C:\\temp\\sampledb_log.ldf']}]" microsoft/mssql-server-windows
 ```
 
 <a name=sample-details></a>


### PR DESCRIPTION
There is a line break in **sampledb_log.ldf** in the `attach_dbs` variable

Please also update this in 
https://hub.docker.com/r/microsoft/mssql-server-windows-developer/
and 
https://hub.docker.com/r/microsoft/mssql-server-windows-express/