### PR TITLE
Remove Deprecated "Maintainer" Instruction

### DIFF
--- a/linux/mssql-tools/Dockerfile
+++ b/linux/mssql-tools/Dockerfile
@@ -1,6 +1,7 @@
 # SQL Server Command Line Tools
 FROM ubuntu:16.04
-MAINTAINER SQL Server Engineering Team
+
+LABEL maintainer="SQL Server Engineering Team"
 
 # apt-get and system utilities
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated