### PR TITLE
Cleanup MSSQL-Tools docker image

### DIFF
--- a/linux/mssql-tools/Dockerfile
+++ b/linux/mssql-tools/Dockerfile
@@ -3,29 +3,30 @@ FROM ubuntu:16.04
 
 LABEL maintainer="SQL Server Engineering Team"
 
-# apt-get and system utilities
-RUN apt-get update && apt-get install -y \
-	curl apt-transport-https debconf-utils \
+# Disable interactive installer
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system utilities
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+            curl ca-certificates apt-transport-https debconf-utils locales \
     && rm -rf /var/lib/apt/lists/*
 
-# adding custom MS repository
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+# Add Microsoft ubuntu repository
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-# install SQL Server drivers and tools
-RUN apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
-RUN /bin/bash -c "source ~/.bashrc"
+# Install SQL Server drivers and tools
+RUN apt-get update \
+    && ACCEPT_EULA=Y apt-get install --no-install-recommends -y \
+            msodbcsql mssql-tools \
+    && rm -rf /var/lib/apt/lists/*
 
+# Setup PATH
+ENV PATH="${PATH}:/opt/mssql-tools/bin"
 
-
-RUN apt-get -y install locales
+# Setup locales
 RUN locale-gen en_US.UTF-8
-RUN update-locale LANG=en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-
-
-CMD /bin/bash 
-
-
-
+CMD ["/bin/bash"]


### PR DESCRIPTION
- Use apt non-interactive mode
- Reduce calls to apt-get
- Delete packages cache after installs
- Reduce layers number
- Use a cleaner way to set PATH and locale
- Use exec syntax for CMD
- Reduce image size from `232 MB` to `190 MB`