### PR TITLE
Remove export of DEBIAN_FRONTEND

### DIFF
--- a/linux/preview/examples/mssql-agent-fts-ha-tools/Dockerfile
+++ b/linux/preview/examples/mssql-agent-fts-ha-tools/Dockerfile
@@ -6,8 +6,7 @@
 FROM ubuntu:16.04
 
 # Install prerequistes since it is needed to get repo config for SQL server
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -yq curl apt-transport-https && \
     # Get official Microsoft repository configuration
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \


### PR DESCRIPTION
See https://docs.docker.com/engine/faq/#why-is-debian_frontendnoninteractive-discouraged-in-dockerfiles
for the harm that it can cause unintentionally to anyone who opens a
shell in the image or any downstream images.