### PR TITLE
Change PATH set

### DIFF
--- a/linux/mssql-tools/Dockerfile
+++ b/linux/mssql-tools/Dockerfile
@@ -14,10 +14,7 @@ RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt
 
 # install SQL Server drivers and tools
 RUN apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
-RUN /bin/bash -c "source ~/.bashrc"
-
-
+ENV PATH="$PATH:/opt/mssql-tools/bin"
 
 RUN apt-get -y install locales
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Hello!
In this PR, the PATH is set with docker ENV primitive instead of adding it to .bashrc

**Why:**
The expected behavior of a docker image is to use containerized services. In particular, I try to use it in a CI process, but the CI process does not start a bash interactive terminal, so the PATH modification in .bashrc was not executed. 
The current image works with interactive bash sessions only, this PR would increase its capabilities without any drawback (up to my knowledge).

**Test:**
(set PWD to the specific Dockerfile directory)
```bash
docker build . -t mssqltoolstest
docker run --rm mssqltoolstest sqlcmd -?
```

   * **Before behaviour**: sqlcmd executable file not found in $PATH": unknown.
   * **After PR behaviour**: show help screen 

