### PR TITLE
Moving to newest "FROM" base image

### DIFF
--- a/windows/mssql-server-windows-developer/dockerfile
+++ b/windows/mssql-server-windows-developer/dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/windowsservercore
+ARG  FROM_TAG=ltsc2019
+FROM mcr.microsoft.com/windows/servercore:${FROM_TAG}
 
 LABEL maintainer "Perry Skountrianos"
 

--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -10,7 +10,10 @@ param(
 [string]$ACCEPT_EULA,
 
 [Parameter(Mandatory=$false)]
-[string]$attach_dbs
+[string]$attach_dbs,
+
+[Parameter(Mandatory=$false)]
+[string]$MSSQL_AGENT_ENABLED
 )
 
 
@@ -67,6 +70,12 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
 }
 
 Write-Verbose "Started SQL Server."
+
+if($MSSQL_AGENT_ENABLED -eq "true" -Or $MSSQL_AGENT_ENABLED -eq $true)
+{
+	Write-Verbose "Starting SQL Agent"
+	start-service SQLSERVERAGENT
+}
 
 $lastCheck = (Get-Date).AddSeconds(-2) 
 while ($true) 


### PR DESCRIPTION
I've had some problem to run this container on windows 2019. There are many issues about that and the latest not being a good practice any more so I've changed the base from microsoft/windowsservercore to mcr.microsoft.com/windows/servercore with an arg to able users to change that as needed.

It´s a suggestion and would be great if you guys could do so.

*may have some backwards compatibility issues