### PR TITLE
Fix mssql-mlservices sample and make it work with SQL server 2019

### DIFF
--- a/linux/preview/examples/mssql-mlservices/Dockerfile
+++ b/linux/preview/examples/mssql-mlservices/Dockerfile
@@ -5,7 +5,12 @@ FROM ubuntu:16.04
 COPY ./supervisord.conf /usr/local/etc/supervisord.conf
 
 # install supporting packages
-RUN apt-get update
+RUN apt-get update && \
+    apt-get install -y apt-transport-https curl && \
+    # Adding custom MS repository
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2019.list > /etc/apt/sources.list.d/mssql-server-2019.list
+    
 RUN apt-get install -y supervisor \
                        fakechroot \
                        locales \
@@ -24,15 +29,15 @@ RUN apt-get install -y supervisor \
                        libsss-nss-idmap-dev \
                        software-properties-common
 
-# register Microsoft package repository
-#TODO: This needs to be updated when SQL Server 2019 is generally available
-RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-RUN add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-preview.list)"
-
 # install SQL Server ML services R and Python packages which will also install the mssql-server pacakge, the package for SQL Server itself
 # if you want to install only Python or only R, you can add/remove the package as needed below
-RUN apt-get update
-RUN apt-get install -y mssql-mlservices-packages-r  mssql-mlservices-packages-py
+RUN apt-get update && \
+    apt-get install -y mssql-mlservices-packages-r \
+                       mssql-mlservices-packages-py && \
+    # Cleanup the Dockerfile
+    apt-get clean && \
+    rm -rf /var/apt/cache/* /tmp/* /var/tmp/* /var/lib/apt/lists
+    
 
 # run checkinstallextensibility.sh
 RUN /opt/mssql/bin/checkinstallextensibility.sh
@@ -45,9 +50,6 @@ RUN mkdir -p /var/opt/mssql-extensibility/log
 RUN chown -R root:root /var/opt/mssql-extensibility
 RUN chmod -R 777 /var/opt/mssql-extensibility
 
-# cleanup
-RUN apt-get clean
-RUN rm -rf /var/apt/cache/* /tmp/* /var/tmp/*
 
 # locale-gen
 RUN locale-gen en_US.UTF-8

--- a/linux/preview/examples/mssql-mlservices/build-container
+++ b/linux/preview/examples/mssql-mlservices/build-container
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t mssql-server-mlservices .

--- a/linux/preview/examples/mssql-mlservices/run-container
+++ b/linux/preview/examples/mssql-mlservices/run-container
@@ -1,0 +1,13 @@
+#!/bin/bash
+docker container run \
+    --name sql-ml \
+    --env 'ACCEPT_EULA=Y' \
+    --env 'MSSQL_PID=Developer' \
+    --env 'ACCEPT_EULA_ML=Y' \
+    --env 'SA_PASSWORD=My!SuperSecretPassw0rd' \
+    --env 'MSSQL_SA_PASSWORD=My!SuperSecretPassw0rd' \
+    -v /tmp/mssql:/var/opt/mssql \
+    --publish 1433:1433 \
+    --detach \
+    mssql-server-mlservices
+    


### PR DESCRIPTION
The sample Dockerfile provided to run ML-Services (linux/preview/examples/mssql-mlservices/Dockerfile) does not work (see #403 and https://github.com/MicrosoftDocs/sql-docs/issues/4742).

This is due to the sample referring to a preview SQL server repository, which seems to contain a time-locked version of SQL server not working anymore today. Images build based on this version die with `Error: The evaluation period has expired`

The suggested change fixes this by making the Dockerfile use the SQL Server 2019 repositories (thanks to @dbamaster, who identified the very same problem for the polybase sample).