### PR TITLE
feat: run init sql script on first time run

### DIFF
--- a/windows/mssql-server-windows-developer/readme.md
+++ b/windows/mssql-server-windows-developer/readme.md
@@ -76,6 +76,27 @@ The image provides two environment variables to optionally set: </br>
 	The path has double backslashes for escaping!
 	The path refers to files **within the container**. So make sure to include them in the image or mount them via **-v**!
 
+## Alternative : init sql scripts
+
+The previous sample describes how to mount the ldf and mdf files into the container. 
+Another approach consists of running setup script at sql server startup.
+By mounting a volume from local folder scripts to c:/docker-entrypoint-initdb, the container will execute all .sql scripts files
+The volume should be a directory
+````
+version: "3.8"
+
+services:
+  sqlserver:
+    platform: windows/amd64
+    environment: 
+      - sa_password=<YourPassword>
+      - ACCEPT_EULA=Y
+    image: microsoft/mssql-server-windows-developer
+    volumes: 
+      - ./dockerfiles/sqlserver/initdb:c:/docker-entrypoint-initdb:ro
+    ports:
+      - "1433:1433"
+```
 
 This example shows all parameters in action:
 ```

--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -69,7 +69,7 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
 Write-Verbose "Started SQL Server."
 
 if ($(Test-Path c:\.initialized) -eq $False) {
-    Get-ChildItem -ErrorAction SilentlyContinue C:\docker-entrypoint-initdb\ *.sql | % { Write-Verbose "Executing $($_.FullName) file"; sqlcmd -U sa -P $env:sa_password -i $_.FullName }
+    Get-ChildItem -ErrorAction SilentlyContinue C:\docker-entrypoint-initdb\ *.sql | % { Write-Verbose "Executing $($_.FullName) file"; sqlcmd -U sa -P $env:sa_password -i $_.FullName | Out-Null }
     echo ok > c:\.initialized
 }
 

--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -66,12 +66,12 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
 	}
 }
 
-Write-Verbose "Started SQL Server."
-
 if ($(Test-Path c:\.initialized) -eq $False) {
     Get-ChildItem -ErrorAction SilentlyContinue C:\docker-entrypoint-initdb\ *.sql | % { Write-Verbose "Executing $($_.FullName) file"; sqlcmd -U sa -P $env:sa_password -i $_.FullName | Out-Null }
     echo ok > c:\.initialized
 }
+
+Write-Verbose "Started SQL Server."
 
 $lastCheck = (Get-Date).AddSeconds(-2) 
 while ($true) 

--- a/windows/mssql-server-windows-developer/start.ps1
+++ b/windows/mssql-server-windows-developer/start.ps1
@@ -68,6 +68,11 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
 
 Write-Verbose "Started SQL Server."
 
+if ($(Test-Path c:\.initialized) -eq $False) {
+    Get-ChildItem -ErrorAction SilentlyContinue C:\docker-entrypoint-initdb\ *.sql | % { Write-Verbose "Executing $($_.FullName) file"; sqlcmd -U sa -P $env:sa_password -i $_.FullName }
+    echo ok > c:\.initialized
+}
+
 $lastCheck = (Get-Date).AddSeconds(-2) 
 while ($true) 
 { 

--- a/windows/mssql-server-windows-express/start.ps1
+++ b/windows/mssql-server-windows-express/start.ps1
@@ -67,6 +67,11 @@ if ($null -ne $dbs -And $dbs.Length -gt 0)
     }
 }
 
+if ($(Test-Path c:\.initialized) -eq $False) {
+    Get-ChildItem -ErrorAction SilentlyContinue C:\docker-entrypoint-initdb\ *.sql | % { Write-Verbose "Executing $($_.FullName) file"; sqlcmd -U sa -P $env:sa_password -i $_.FullName | Out-Null }
+    echo ok > c:\.initialized
+}
+
 Write-Verbose "Started SQL Server."
 
 $lastCheck = (Get-Date).AddSeconds(-2) 


### PR DESCRIPTION
Using init scripts is a quite common pattern in sql docker images like mysql does for instance.

The purpose of this PR is to add into the start.ps1 the ability to check the folder docker-entrypoint-initdb and run all sql scripts inside. Once it is done, the script creates a flag file to avoid running the setup phase on the next startup after a stop.

I updated the README as an alternative.

Let's discuss!