### PR TITLE
Update Docker Hub url of SQL Server on Linux

### DIFF
--- a/linux/preview/README.md
+++ b/linux/preview/README.md
@@ -1,6 +1,6 @@
 # Introduction
 There are five Linux-based Docker container images documented here:
-* A representation of the actual [Dockerfile](Ubuntu/Dockerfile) that is used by Microsoft to build the Ubuntu-based image [mssql-server-linux](https://hub.docker.com/r/microsoft/mssql-server-linux/)  which is available at Docker Hub.
+* A representation of the actual [Dockerfile](Ubuntu/Dockerfile) that is used by Microsoft to build the Ubuntu-based image [mssql-server-linux](https://hub.docker.com/_/microsoft-mssql-server)  which is available at Docker Hub.
 * A [Dockerfile](CentOS/Dockerfile) for building a CentOS-based image on your own
 * A [Dockerfile](RHEL/Dockerfile) for building a RHEL-based image on your own
 * A [Dockerfile](SLES/dockerfile) for building a SLES-based image on your own
@@ -12,7 +12,7 @@ Learn more about the latest release of SQL Server on Linux here: [SQL Server on 
 
 # mssql-server-linux
 
-This Ubuntu-based image is built and maintened by Microsoft, and published on [Docker Hub](https://hub.docker.com/r/microsoft/mssql-server-linux/).
+This Ubuntu-based image is built and maintened by Microsoft, and published on [Docker Hub](https://hub.docker.com/_/microsoft-mssql-server).
 
 # mssql-server-centos
 

--- a/oss-drivers/msphpsql/README.md
+++ b/oss-drivers/msphpsql/README.md
@@ -1,6 +1,6 @@
 # PHP Development Environment for SQL Server
 
-This image provides an integrated development environment for PHP with connectivity to a remote SQL Server database. Learn more about [SQL Server on Linux](https://hub.docker.com/r/microsoft/mssql-server-linux/). To report issues or provide feedback, please file an issue in the [SQL Server in Docker GitHub Repository](https://github.com/Microsoft/mssql-docker).
+This image provides an integrated development environment for PHP with connectivity to a remote SQL Server database. Learn more about [SQL Server on Linux](https://hub.docker.com/_/microsoft-mssql-server). To report issues or provide feedback, please file an issue in the [SQL Server in Docker GitHub Repository](https://github.com/Microsoft/mssql-docker).
 
 ### [Dockerfile](https://github.com/Microsoft/mssql-docker/blob/master/oss-drivers//msphpsql/Dockerfile)
 

--- a/oss-drivers/pyodbc/README.md
+++ b/oss-drivers/pyodbc/README.md
@@ -1,6 +1,6 @@
 # Python Development Environment for SQL Server
 
-This image provides an integrated development environment for Python with connectivity to a remote SQL Server database. Learn more about [SQL Server on Linux](https://hub.docker.com/r/microsoft/mssql-server-linux/). To report issues or provide feedback, please file an issue in the [SQL Server in Docker GitHub Repository](https://github.com/Microsoft/mssql-docker).
+This image provides an integrated development environment for Python with connectivity to a remote SQL Server database. Learn more about [SQL Server on Linux](https://hub.docker.com/_/microsoft-mssql-server). To report issues or provide feedback, please file an issue in the [SQL Server in Docker GitHub Repository](https://github.com/Microsoft/mssql-docker).
 
 ### [Dockerfile](https://github.com/Microsoft/mssql-docker/blob/master/oss-drivers/pyodbc/Dockerfile)
 

--- a/oss-drivers/tedious/README.md
+++ b/oss-drivers/tedious/README.md
@@ -1,6 +1,6 @@
 # Node.js Development Environment for SQL Server
 
-This image provides an integrated development environment for Node.js with connectivity to a remote SQL Server database. Learn more about [SQL Server on Linux](https://hub.docker.com/r/microsoft/mssql-server-linux/). To report issues or provide feedback, please file an issue in the [SQL Server in Docker GitHub Repository](https://github.com/Microsoft/mssql-docker).
+This image provides an integrated development environment for Node.js with connectivity to a remote SQL Server database. Learn more about [SQL Server on Linux](https://hub.docker.com/_/microsoft-mssql-server). To report issues or provide feedback, please file an issue in the [SQL Server in Docker GitHub Repository](https://github.com/Microsoft/mssql-docker).
 
 ### [Dockerfile](https://github.com/Microsoft/mssql-docker/blob/master/oss-drivers/tedious/Dockerfile)
 


### PR DESCRIPTION
On the old page https://hub.docker.com/r/microsoft/mssql-server-linux/, it says:

> **We've moved!**
> 
> We are moving to mcr.microsoft.com where you can pull the latest SQL Server 2017 and SQL Server 2019 on Linux containers. We will no longer be updating this container repo with updates, and we will eventually remove all container images from this repo.
> 
> Visit our new Docker Hub page at https://hub.docker.com/r/microsoft/mssql-server 