### PR TITLE
Fix Linux MSSQL Customize Examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Explicitly declare text files you want to always be normalized and converted to native line endings on checkout.
+*.sh text eol=lf

--- a/linux/preview/examples/mssql-customize/README.md
+++ b/linux/preview/examples/mssql-customize/README.md
@@ -24,7 +24,7 @@ docker build -t mssql-custom .
 
 Then spin up a new container using `docker run`
 ```
-docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=StrongPassw0rd' -p 1433:1433 --name sql1 -d mssql-custom
+docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=StrongPassw0rd" -p 1433:1433 --name sql1 -d mssql-custom
 ```
 
 Note: MSSQL passwords must be at least 8 characters long, contain upper case, lower case and digits.  

--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -9,14 +9,14 @@ DBSTATUS=1
 ERRCODE=1
 i=0
 
-while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
+while [[ $DBSTATUS -ne 0 || $ERRCODE -ne 0 ]] && [[ $i -lt 60 ]]; do
 	i=$i+1
 	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
 	ERRCODE=$?
 	sleep 1
 done
 
-if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then 
+if [[ $DBSTATUS -ne 0 ]] || [[ $ERRCODE -ne 0 ]]; then
 	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
 	exit 1
 fi


### PR DESCRIPTION
The Linux MSSQL Example had logic errors, as well as breaking (non-executing) code. In addition the README was updated to be platform agnostic (previously it did NOT work on windows). The gitattributes was added to ease with windows development and line endings on bash/shell scripts.