### PR TITLE
Update Dockerfile

### DIFF
--- a/linux/preview/examples/mssql-mlservices/Dockerfile
+++ b/linux/preview/examples/mssql-mlservices/Dockerfile
@@ -1,5 +1,5 @@
 # Maintainers: Microsoft Corporation 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 # copy in supervisord conf file
 COPY ./supervisord.conf /usr/local/etc/supervisord.conf


### PR DESCRIPTION
Update OS to latest long term support (LTS) version.  v22.04 Improves security and maintainability.