### PR TITLE
update dockerfile.alpine

### DIFF
--- a/linux/mssql-tools/Dockerfile.alpine
+++ b/linux/mssql-tools/Dockerfile.alpine
@@ -25,4 +25,4 @@ RUN apk add --allow-untrusted msodbcsql18_18.0.1.1-1_amd64.apk \
 	&& rm -f msodbcsql18_18.0.1.1-1_amd64.apk mssql-tools18_18.0.1.1-1_amd64.apk
 
 
-CMD /bin/bash 
+CMD /bin/ash 


### PR DESCRIPTION
since there is no bash in alpine , executing /bin/bash throws :
`/bin/bash : no such file or directory. unknown`
we have to use either ash or sh.