### PR TITLE
use v1 api & bump to 2022

### DIFF
--- a/linux/sample-helm-chart-statefulset-deployment/templates/sc.yaml
+++ b/linux/sample-helm-chart-statefulset-deployment/templates/sc.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
      name: azure-disk
 provisioner: kubernetes.io/azure-disk

--- a/linux/sample-helm-chart-statefulset-deployment/values.yaml
+++ b/linux/sample-helm-chart-statefulset-deployment/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: mcr.microsoft.com/mssql/server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2019-latest"
+  tag: "2022-latest"
 
 ACCEPT_EULA:
     value: "y"


### PR DESCRIPTION
- Use v1 api as it is not beta
- Use 2022 SQL Server docker image