### PR TITLE
Fix configure db script

### DIFF
--- a/linux/preview/examples/mssql-customize/Dockerfile
+++ b/linux/preview/examples/mssql-customize/Dockerfile
@@ -7,8 +7,4 @@ WORKDIR /usr/config
 # Bundle config source
 COPY . /usr/config
 
-# Grant permissions for to our scripts to be executable
-RUN chmod +x /usr/config/entrypoint.sh
-RUN chmod +x /usr/config/configure-db.sh
-
 ENTRYPOINT ["./entrypoint.sh"]

--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -13,7 +13,7 @@ while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt $TRIES ]]; do
 	i=$((i+1))
 	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MSSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases" > /dev/null 2>&1) || DBSTATUS=1
 	
-	sleep 1
+	sleep 1s
 done
 
 if [ $DBSTATUS -ne 0 ]; then 

--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -1,26 +1,29 @@
 #!/bin/bash
 
-# Wait 60 seconds for SQL Server to start up by ensuring that 
-# calling SQLCMD does not return an error code, which will ensure that sqlcmd is accessible
-# and that system and user databases return "0" which means all databases are in an "online" state
+# Calls SQLCMD to verify that system and user databases return "0" which means all databases are in an "online" state,
+# then run the configuration script (setup.sql)
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2017 
 
+TRIES=60
 DBSTATUS=1
 ERRCODE=1
 i=0
 
-while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
-	i=$i+1
-	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
-	ERRCODE=$?
+while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt $TRIES ]]; do
+	i=$((i+1))
+	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MSSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases" > /dev/null 2>&1) || DBSTATUS=1
+	
 	sleep 1
 done
 
-if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then 
-	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
+if [ $DBSTATUS -ne 0 ]; then 
+	echo "SQL Server took more than $TRIES seconds to start up or one or more databases are not in an ONLINE state"
 	exit 1
 fi
 
 # Run the setup script to create the DB and the schema in the DB
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql
+echo "Running configuration script..."
 
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -d master -i setup.sql
+
+echo "Configuration completed."

--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -11,7 +11,7 @@ i=0
 
 while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt $TRIES ]]; do
 	i=$((i+1))
-	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MSSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases" > /dev/null 2>&1) || DBSTATUS=1
+	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MSSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select COALESCE(SUM(state), 0) from sys.databases") || DBSTATUS=1
 	
 	sleep 1s
 done


### PR DESCRIPTION
The `configure.db` file is referenced in the Docker Hub documentation but does not work.

**Fixes:**
- Variable `i` was being concatenated instead of incremented, making the script not wait for SQL Server to boot;
- Ignoring errors from the `select SUM(state) from sys.databases` command;
- Changed `SA_PASSWORD` variable to `MSSQL_SA_PASSWORD` (The correct one);
- Removed `chmod` from Dockerfile.

**Improvements:**
- Configurable number of retries;
- Explicit unit of time (seconds) on the `sleep` command;