### PR TITLE
Fixed bugs with configure-db.sh and updated Dockerfile.

### DIFF
--- a/linux/preview/examples/mssql-customize/Dockerfile
+++ b/linux/preview/examples/mssql-customize/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2017-latest
+FROM mcr.microsoft.com/mssql/server:2022-latest
 
 # Create a config directory
 RUN mkdir -p /usr/config

--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -3,20 +3,30 @@
 # Wait 60 seconds for SQL Server to start up by ensuring that 
 # calling SQLCMD does not return an error code, which will ensure that sqlcmd is accessible
 # and that system and user databases return "0" which means all databases are in an "online" state
-# https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2017 
+# https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2022
 
-DBSTATUS=1
+DBSTATUS=""
+DBSTATUSSUM=0
 ERRCODE=1
 i=0
 
-while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
-	i=$i+1
+while [[ "1" == "1" ]]; do
+
+	i=$(($i+1))
 	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
+	DBSTATUSSUM=$(($DBSTATUS))
 	ERRCODE=$?
+
+	if [[ "$DBSTATUS" != "" ]] && [[ $DBSTATUSSUM -eq 0 ]] && [[ $ERRCODE -eq 0 ]]; then
+		break
+	elif [[ $i -gte 60 ]]; then
+		break
+	fi
+
 	sleep 1
 done
 
-if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then 
+if [[ "$DBSTATUS" == "" ]] || [[ $DBSTATUSSUM -ne 0 ]] || [[ $ERRCODE -ne 0 ]]; then 
 	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
 	exit 1
 fi


### PR DESCRIPTION
The configure-db.sh script was exiting from the loop before a MS SQL 2022 server had actually started.  This was causing some SQL statements not to run sometimes.