### PR TITLE
Add double bracket to fix bash syntax in configure-db

### DIFF
--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -16,7 +16,7 @@ while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
 	sleep 1
 done
 
-if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then 
+if [[ $DBSTATUS -ne 0 ]] || [[ $ERRCODE -ne 0 ]]; then
 	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
 	exit 1
 fi


### PR DESCRIPTION
The configure-db.sh script currently has a syntax error that produces this error:
`/usr/config/configure-db.sh: line 19: [: too many arguments`

This PR adds the needed brackets so this error goes away.