### PR TITLE
Linux docker README- links on Github seem to be case sensitive

### DIFF
--- a/linux/preview/README.md
+++ b/linux/preview/README.md
@@ -3,8 +3,8 @@ There are five Linux-based Docker container images documented here:
 * A representation of the actual [Dockerfile](Ubuntu/Dockerfile) that is used by Microsoft to build the Ubuntu-based image [mssql-server-linux](https://hub.docker.com/r/microsoft/mssql-server-linux/)  which is available at Docker Hub.
 * A [Dockerfile](CentOS/Dockerfile) for building a CentOS-based image on your own
 * A [Dockerfile](RHEL/Dockerfile) for building a RHEL-based image on your own
-* A [Dockerfile](SLES/dockerfile) for building a SLES-based image on your own
-* A [Dockerfile](openSUSE/dockerfile) for building an openSUSE-based image on your own
+* A [Dockerfile](SLES/Dockerfile) for building a SLES-based image on your own
+* A [Dockerfile](openSUSE/Dockerfile) for building an openSUSE-based image on your own
 
 Full documentation can be found at the [SQL Server on Linux Docker image page](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-docker).
 


### PR DESCRIPTION
In those two cases the links containing `/dockerfile` lead to 404 when viewing on Github.