### PR TITLE
Update configure-db.sh status comparison and loop condition

### DIFF
--- a/linux/preview/examples/mssql-customize/configure-db.sh
+++ b/linux/preview/examples/mssql-customize/configure-db.sh
@@ -1,25 +1,33 @@
 #!/bin/bash
-
+set -o pipefail
 # Wait 60 seconds for SQL Server to start up by ensuring that 
 # calling SQLCMD does not return an error code, which will ensure that sqlcmd is accessible
 # and that system and user databases return "0" which means all databases are in an "online" state
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-databases-transact-sql?view=sql-server-2017 
 
-DBSTATUS=1
-ERRCODE=1
-i=0
+declare DBSTATUS
+declare ERRCODE
+TIMEOUT=60
+START=$(date +%s)
+echo "Configure DB script started at $(date)"
 
-while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]] && [[ $ERRCODE -ne 0 ]]; do
-	i=$i+1
-	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $SA_PASSWORD -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
-	ERRCODE=$?
-	sleep 1
+while true; do
+  DELTA=$(($(date +%s) - START))
+  if [[ $DELTA -gt $TIMEOUT ]]; then
+    echo "ERROR: SQL Server took more than ${TIMEOUT} seconds to START up or one or more databases are not in an ONLINE state"
+    exit 1
+  fi
+
+  DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P ${MSSQL_SA_PASSWORD} -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases" 2>/dev/null | sed -e 's/^[[:space:]]*//')
+  ERRCODE=$?
+  if [[ "$DBSTATUS" -eq "0" && "$ERRCODE" -eq "0" ]]; then
+    echo "INFO: Database ready."
+    break
+  else
+    echo "INFO: Waiting for database to be ready..."
+    sleep 1
+  fi
 done
-
-if [ $DBSTATUS -ne 0 ] OR [ $ERRCODE -ne 0 ]; then 
-	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
-	exit 1
-fi
 
 # Run the setup script to create the DB and the schema in the DB
 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql


### PR DESCRIPTION
Changed DBSTATUS to be striped of spaces. 
The comparison of DBSTATUS and ERRCODE was changed to a string comparison, because the return value of sqlcmd when DB is not ready is an empty string.