### PR TITLE
Update README.md

### DIFF
--- a/linux/preview/README.md
+++ b/linux/preview/README.md
@@ -60,7 +60,7 @@ $ make run
 ##  Connect to Microsoft SQL Server
 Starting with the CTP 1.4 (March 17, 2017) release the mssql-tools package including sqlcmd, bcp are included in the image.  You can connect to the SQL Server using the sqlcmd tool inside of the container by using the following command on the host:
 ```
-docker exec -it <container_id|container_name> /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P <your_password>
+docker exec -it <container_id|container_name> /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P <your_password>
 ```
 You can also use the tools in an entrypoint.sh script to do things like create databases or logins, attach databases, import data, or other setup tasks.  See this example of [using an entrypoint.sh script to create a database and schema and bcp in some data](https://github.com/twright-msft/mssql-node-docker-demo-app).
 


### PR DESCRIPTION
The SQL Server Docker image documentation specifically (2017:latest, 2019:latest, 2022:latest) the path to the `sqlcmd` tool as `/opt/mssql-tools/bin/sqlcmd`. However, the correct path is `/opt/mssql-tools18/bin/sqlcmd`. This commit updates the documentation to reflect the correct directory path, preventing errors when users attempt to run `sqlcmd` inside the container.

![image](https://github.com/user-attachments/assets/20ef1282-28ab-4e78-bc21-2c8318cc17e8)
